### PR TITLE
Added support for the LPC1343 USBug board.

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -157,6 +157,7 @@
 			</storageModule>
 			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
 			<storageModule moduleId="org.eclipse.cdt.core.language.mapping"/>
+			<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
 		</cconfiguration>
 	</storageModule>
 	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
@@ -165,11 +166,8 @@
 	<storageModule moduleId="com.crt.config">
 		<projectStorage>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&#13;
 &lt;TargetConfig&gt;&#13;
-&lt;Properties property_0="" property_1="" property_3="NXP" property_4="LPC1343" property_count="5" version="1"/&gt;&#13;
-&lt;infoList vendor="NXP"&gt;&#13;
-&lt;info chip="LPC1343" match_id="0x3d00002b" name="LPC1343" stub="crt_emu_lpc11_13_nxp"&gt;&#13;
-&lt;chip&gt;&#13;
-&lt;name&gt;LPC1343&lt;/name&gt;&#13;
+&lt;Properties property_0="" property_3="NXP" property_4="LPC1343" property_count="5" version="1"/&gt;&#13;
+&lt;infoList vendor="NXP"&gt;&lt;info chip="LPC1343" match_id="0x3d00002b" name="LPC1343" stub="crt_emu_lpc11_13_nxp"&gt;&lt;chip&gt;&lt;name&gt;LPC1343&lt;/name&gt;&#13;
 &lt;family&gt;LPC13xx&lt;/family&gt;&#13;
 &lt;vendor&gt;NXP (formerly Philips)&lt;/vendor&gt;&#13;
 &lt;reset board="None" core="Real" sys="Real"/&gt;&#13;
@@ -200,8 +198,7 @@
 &lt;peripheralInstance derived_from="LPC17_NVIC" determined="infoFile" id="NVIC" location="0xe000e000"/&gt;&#13;
 &lt;peripheralInstance derived_from="CM3_DCR" determined="infoFile" id="DCR" location="0xe000edf0"/&gt;&#13;
 &lt;/chip&gt;&#13;
-&lt;processor&gt;&#13;
-&lt;name gcc_name="cortex-m3"&gt;Cortex-M3&lt;/name&gt;&#13;
+&lt;processor&gt;&lt;name gcc_name="cortex-m3"&gt;Cortex-M3&lt;/name&gt;&#13;
 &lt;family&gt;Cortex-M&lt;/family&gt;&#13;
 &lt;/processor&gt;&#13;
 &lt;link href="nxp_lpc11_13_peripheral.xme" show="embed" type="simple"/&gt;&#13;

--- a/projectconfig.h
+++ b/projectconfig.h
@@ -120,14 +120,20 @@
 
         LPC1343 LPCXpresso board
 
+    CFG_BRD_LPC1343_USBUG
+    ==============================
+
+        LPC1343 USBug board
+
     -----------------------------------------------------------------------*/
-    #define CFG_BRD_LPC1343_REFDESIGN
+    // #define CFG_BRD_LPC1343_REFDESIGN
     // #define CFG_BRD_LPC1343_REFDESIGN_MINIMAL
     // #define CFG_BRD_LPC1343_TFTLCDSTANDALONE_USB
     // #define CFG_BRD_LPC1343_TFTLCDSTANDALONE_UART
     // #define CFG_BRD_LPC1343_802154USBSTICK
     // #define CFG_BRD_LPC1343_OLIMEX_P
     // #define CFG_BRD_LPC1343_LPCXPRESSO
+    #define CFG_BRD_LPC1343_USBUG
 /*=========================================================================*/
 
 
@@ -314,6 +320,13 @@
       // #define GPIO_ENABLE_IRQ2
       // #define GPIO_ENABLE_IRQ3
     #endif
+
+    #ifdef CFG_BRD_LPC1343_USBUG
+      // #define GPIO_ENABLE_IRQ0
+      #define GPIO_ENABLE_IRQ1
+      // #define GPIO_ENABLE_IRQ2
+      // #define GPIO_ENABLE_IRQ3
+    #endif
 /*=========================================================================*/
 
 
@@ -384,6 +397,11 @@
       #define CFG_UART_BAUDRATE           (115200)
       #define CFG_UART_BUFSIZE            (512)
     #endif
+
+    #ifdef CFG_BRD_LPC1343_USBUG
+      #define CFG_UART_BAUDRATE           (115200)
+      #define CFG_UART_BUFSIZE            (512)
+    #endif
 /*=========================================================================*/
 
 
@@ -421,6 +439,11 @@
     #endif
 
     #ifdef CFG_BRD_LPC1343_LPCXPRESSO
+      #define CFG_SSP0_SCKPIN_2_11
+      // #define CFG_SSP0_SCKPIN_0_6
+    #endif
+
+    #ifdef CFG_BRD_LPC1343_USBUG
       #define CFG_SSP0_SCKPIN_2_11
       // #define CFG_SSP0_SCKPIN_0_6
     #endif
@@ -469,6 +492,11 @@
 
     #ifdef CFG_BRD_LPC1343_LPCXPRESSO
       #define ADC_AVERAGING_ENABLE    (0)
+      #define ADC_AVERAGING_SAMPLES   (5)
+    #endif
+
+    #ifdef CFG_BRD_LPC1343_USBUG
+      #define ADC_AVERAGING_ENABLE    (1)
       #define ADC_AVERAGING_SAMPLES   (5)
     #endif
 /*=========================================================================*/
@@ -520,6 +548,13 @@
     #endif
 
     #ifdef CFG_BRD_LPC1343_LPCXPRESSO
+      #define CFG_LED_PORT                (0)
+      #define CFG_LED_PIN                 (7)
+      #define CFG_LED_ON                  (0)
+      #define CFG_LED_OFF                 (1)
+    #endif
+
+    #ifdef CFG_BRD_LPC1343_USBUG
       #define CFG_LED_PORT                (0)
       #define CFG_LED_PIN                 (7)
       #define CFG_LED_ON                  (0)
@@ -590,6 +625,13 @@
     #ifdef CFG_BRD_LPC1343_LPCXPRESSO
       // #define CFG_SDCARD
       #define CFG_SDCARD_READONLY         (1) // Must be 0 or 1
+      #define CFG_SDCARD_CDPORT           (3)
+      #define CFG_SDCARD_CDPIN            (0)
+    #endif
+
+    #ifdef CFG_BRD_LPC1343_USBUG
+      // #define CFG_SDCARD
+      #define CFG_SDCARD_READONLY         (1)   // Must be 0 or 1
       #define CFG_SDCARD_CDPORT           (3)
       #define CFG_SDCARD_CDPIN            (0)
     #endif
@@ -675,6 +717,14 @@
       #define CFG_USBCDC_INITTIMEOUT      (5000)
       #define CFG_USBCDC_BUFFERSIZE       (256)
     #endif
+
+    #ifdef CFG_BRD_LPC1343_USBUG
+      // #define CFG_USBHID
+      #define CFG_USBCDC
+      #define CFG_USBCDC_BAUDRATE         (115200)
+      #define CFG_USBCDC_INITTIMEOUT      (5000)
+      #define CFG_USBCDC_BUFFERSIZE       (256)
+    #endif
 /*=========================================================================*/
 
 
@@ -736,6 +786,13 @@
     #endif	
 
     #ifdef CFG_BRD_LPC1343_LPCXPRESSO
+      #define CFG_PRINTF_MAXSTRINGSIZE    (255)
+      // #define CFG_PRINTF_UART
+      #define CFG_PRINTF_USBCDC
+      #define CFG_PRINTF_NEWLINE          "\r\n"
+    #endif
+
+    #ifdef CFG_BRD_LPC1343_USBUG
       #define CFG_PRINTF_MAXSTRINGSIZE    (255)
       // #define CFG_PRINTF_UART
       #define CFG_PRINTF_USBCDC
@@ -902,6 +959,20 @@
       #define CFG_INTERFACE_CONFIRMREADY  (0)
       #define CFG_INTERFACE_LONGSYSINFO   (0)
     #endif
+
+    #ifdef CFG_BRD_LPC1343_USBUG
+      #define CFG_INTERFACE
+      #define CFG_INTERFACE_MAXMSGSIZE    (256)
+      #define CFG_INTERFACE_PROMPT        "LPC1343 >> "
+      #define CFG_INTERFACE_SILENTMODE    (0)
+      #define CFG_INTERFACE_DROPCR        (0)
+      #define CFG_INTERFACE_ENABLEIRQ     (0)
+      #define CFG_INTERFACE_IRQPORT       (0)
+      #define CFG_INTERFACE_IRQPIN        (7)
+      #define CFG_INTERFACE_SHORTERRORS   (0)
+      #define CFG_INTERFACE_CONFIRMREADY  (0)
+      #define CFG_INTERFACE_LONGSYSINFO   (0)
+    #endif
 /*=========================================================================*/
 
 
@@ -979,6 +1050,11 @@
     #endif	
 
     #ifdef CFG_BRD_LPC1343_LPCXPRESSO
+      // #define CFG_I2CEEPROM
+      #define CFG_I2CEEPROM_SIZE          (3072)
+    #endif
+
+    #ifdef CFG_BRD_LPC1343_USBUG
       // #define CFG_I2CEEPROM
       #define CFG_I2CEEPROM_SIZE          (3072)
     #endif
@@ -1131,6 +1207,16 @@
       #define CFG_CHIBI_PROMISCUOUS       (0)
       #define CFG_CHIBI_BUFFERSIZE        (128)
     #endif
+
+    #ifdef CFG_BRD_LPC1343_USBUG
+      // #define CFG_CHIBI
+      #define CFG_CHIBI_MODE              (0)                 // OQPSK_868MHZ
+      #define CFG_CHIBI_POWER             (0xE9)              // CHB_PWR_EU2_3DBM
+      #define CFG_CHIBI_CHANNEL           (0)                 // 868-868.6 MHz
+      #define CFG_CHIBI_PANID             (0x1234)
+      #define CFG_CHIBI_PROMISCUOUS       (0)
+      #define CFG_CHIBI_BUFFERSIZE        (128)
+    #endif
 /*=========================================================================*/
 
 
@@ -1220,6 +1306,14 @@
       #define CFG_TFTLCD_TS_DEFAULTTHRESHOLD (50)
       #define CFG_TFTLCD_TS_KEYPADDELAY      (100)
     #endif
+
+    #ifdef CFG_BRD_LPC1343_USBUG
+      // #define CFG_TFTLCD
+      #define CFG_TFTLCD_INCLUDESMALLFONTS   (0)
+      #define CFG_TFTLCD_USEAAFONTS          (0)
+      #define CFG_TFTLCD_TS_DEFAULTTHRESHOLD (50)
+      #define CFG_TFTLCD_TS_KEYPADDELAY      (100)
+    #endif
 /*=========================================================================*/
 
 
@@ -1284,8 +1378,9 @@
   !defined CFG_BRD_LPC1343_TFTLCDSTANDALONE_UART && \
   !defined CFG_BRD_LPC1343_802154USBSTICK && \
   !defined CFG_BRD_LPC1343_OLIMEX_P && \
-  !defined CFG_BRD_LPC1343_LPCXPRESSO
-  #error "You must defined a target board (CFG_BRD_LPC1343_REFDESIGN or CFG_BRD_LPC1343_REFDESIGN_MINIMAL or CFG_BRD_LPC1343_TFTLCDSTANDALONE or CFG_BRD_LPC1343_TFTLCDSTANDALONE_UART or CFG_BRD_LPC1343_802154USBSTICK or CFG_BRD_LPC1343_LPCXPRESSO)"
+  !defined CFG_BRD_LPC1343_LPCXPRESSO && \
+  !defined CFG_BRD_LPC1343_USBUG
+  #error "You must defined a target board (CFG_BRD_LPC1343_REFDESIGN or CFG_BRD_LPC1343_REFDESIGN_MINIMAL or CFG_BRD_LPC1343_TFTLCDSTANDALONE or CFG_BRD_LPC1343_TFTLCDSTANDALONE_UART or CFG_BRD_LPC1343_802154USBSTICK or CFG_BRD_LPC1343_LPCXPRESSO or CFG_BRD_LPC1343_USBUG)"
 #endif
 
 #if defined CFG_PRINTF_USBCDC && defined CFG_PRINTF_UART


### PR DESCRIPTION
Hi Kevin,

I added support for my LPC1343 USBug breakout board (https://github.com/Squonk42/USBug).

As it is very similar to the original MicroBuilder reference design, only the "projectconfig.h" file is modified (the ".cproject" changes are only related to the fact that I am using the latest LPCXpresso v4.2.2 [Build 275] [03/04/2012]).

Not much tested yet, but at least it compiles ok, and I have both the LED blinking and the command interpreter working on the USB CDC console!

Feel free to integrate it under the BSD license if you are interested.

Regards,
Michel
