### PR TITLE
fix 49.7 day systick rollover

### DIFF
--- a/core/systick/systick.c
+++ b/core/systick/systick.c
@@ -78,10 +78,10 @@ volatile uint32_t systickRollovers = 0;
 /**************************************************************************/
 void SysTick_Handler (void)
 {
-  systickTicks++;
-
   // Increment rollover counter
   if (systickTicks == 0xFFFFFFFF) systickRollovers++;
+
+  systickTicks++;
 
   #ifdef CFG_SDCARD
   fatTicks++;


### PR DESCRIPTION
With a systick set to 1mS, after 49.7 days a rollover occurs. Since the systickTicks counter is incremented prior to the test for a rollover, the result from a call to systickGetSecondsActive() is incorect and the rollover never actually occurs. Moving the increment to after the test fixes it.